### PR TITLE
[CI/CD] Add release workflow

### DIFF
--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -1,0 +1,156 @@
+name: Build, Test, and Package
+
+on:
+  workflow_call:
+    inputs:
+      sha:
+        description: "The last commit sha in the release"
+        type: string
+        required: true
+      version_number:
+        description: "The release version number (i.e. 1.0.0b1)"
+        type: string
+        required: true
+
+permissions:
+  contents: write # this is the permission that allows creating a new release
+
+env:
+  PYTHON_TARGET_VERSION: 3.8
+  ARTIFACT_RETENTION_DAYS: 1
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  log-inputs:
+    name: Log Inputs
+    runs-on: ubuntu-latest
+    steps:
+      - name: "[DEBUG] Print Variables"
+        run: |
+          echo The last commit sha in the release: ${{ inputs.sha }}
+          echo The release version number:         ${{ inputs.version_number }}
+          echo Python target version:              ${{ env.PYTHON_TARGET_VERSION }}
+          echo Artifact retention days:            ${{ env.ARTIFACT_RETENTION_DAYS }}
+
+  unit:
+    name: Unit Test
+
+    runs-on: ubuntu-latest
+
+    env:
+      TOXENV: "unit"
+
+    steps:
+      - name: "Checkout Commit - ${{ inputs.sha }}"
+        uses: actions/checkout@v3
+        with:
+          persist-credentials: false
+          ref: ${{ github.event.inputs.sha }}
+
+      - name: "Set up Python - ${{ env.PYTHON_TARGET_VERSION }}"
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ env.PYTHON_TARGET_VERSION }}
+
+      - name: "Install Python Dependencies"
+        run: |
+          python -m pip install --user --upgrade pip
+          python -m pip install tox
+          python -m pip --version
+          python -m tox --version
+
+      - name: "Run Tox"
+        run: tox
+
+  build:
+    name: Build Packages
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: "Checkout Commit - ${{ inputs.sha }}"
+        uses: actions/checkout@v3
+        with:
+          persist-credentials: false
+          ref: ${{ inputs.sha }}
+
+      - name: "Set up Python - ${{ env.PYTHON_TARGET_VERSION }}"
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ env.PYTHON_TARGET_VERSION }}
+
+      - name: "Install Python Dependencies"
+        run: |
+          python -m pip install --user --upgrade pip
+          python -m pip install --upgrade setuptools wheel twine check-wheel-contents
+          python -m pip --version
+
+      - name: "Build Distributions"
+        run: ./scripts/build-dist.sh
+
+      - name: "[DEBUG] Show Distributions"
+        run: ls -lh dist/
+
+      - name: "Check Distribution Descriptions"
+        run: |
+          twine check dist/*
+
+      - name: "[DEBUG] Check Wheel Contents"
+        run: |
+          check-wheel-contents dist/*.whl --ignore W007,W008
+
+      - name: "Upload Build Artifact - ${{ inputs.version_number }}"
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ inputs.version_number }}
+          path: |
+            dist/
+            !dist/dbt-${{ inputs.version_number }}.tar.gz
+          retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
+
+  test-build:
+    name: Verify Packages
+
+    needs: [unit, build]
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: "Set up Python - ${{ env.PYTHON_TARGET_VERSION }}"
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ env.PYTHON_TARGET_VERSION }}
+
+      - name: "Install Python Dependencies"
+        run: |
+          python -m pip install --user --upgrade pip
+          python -m pip install --upgrade wheel
+          python -m pip --version
+
+      - name: "Download Build Artifact - ${{ inputs.version_number }}"
+        uses: actions/download-artifact@v3
+        with:
+          name: ${{ inputs.version_number }}
+          path: dist/
+
+      - name: "[DEBUG] Show Distributions"
+        run: ls -lh dist/
+
+      - name: "Install Wheel Distributions"
+        run: |
+          find ./dist/*.whl -maxdepth 1 -type f | xargs python -m pip install --force-reinstall --find-links=dist/
+
+      - name: "[DEBUG] Check Wheel Distributions"
+        run: |
+          dbt --version
+
+      - name: "Install Source Distributions"
+        run: |
+          find ./dist/*.gz -maxdepth 1 -type f | xargs python -m pip install --force-reinstall --find-links=dist/
+
+      - name: "[DEBUG] Check Source Distributions"
+        run: |
+          dbt --version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,91 @@
+# **what?**
+# Take the given commit, run unit tests specifically on that sha, build and
+# package it, and then release to GitHub and PyPi with that specific build
+
+# **why?**
+# Ensure an automated and tested release process
+
+# **when?**
+# This will only run manually with a given sha, version, and changelog_path
+
+name: Release to GitHub and PyPi
+
+on:
+  workflow_dispatch:
+    inputs:
+      sha:
+        description: "The last commit sha in the release"
+        required: true
+      version_number:
+        description: "The release version number (i.e. 1.0.0b1)"
+        required: true
+      changelog_path:
+        description: "Path to changes log"
+        type: string
+        default: "./CHANGELOG.md"
+        required: false
+      test_run:
+        description: "Test run (Publish release as draft)"
+        type: boolean
+        default: false
+        required: false
+
+permissions:
+  contents: write # this is the permission that allows creating a new release
+
+jobs:
+  log-inputs:
+    name: Log Inputs
+    runs-on: ubuntu-latest
+    steps:
+      - name: "[DEBUG] Print Variables"
+        run: |
+          echo The last commit sha in the release: ${{ inputs.sha }}
+          echo The release version number:         ${{ inputs.version_number }}
+          echo Expected Changlog path:             ${{ inputs.changelog_path }}
+          echo Test run:                           ${{ inputs.test_run }}
+
+  build-test-package:
+    name: Build, Test, and Package
+
+    uses: dbt-labs/dbt-snowflake-release-test/.github/workflows/build-test-package.yml@main
+
+    with:
+      sha: ${{ inputs.sha }}
+      version_number: ${{ inputs.version_number }}
+
+  github-release:
+    name: GitHub Release
+
+    needs: build-test-package
+
+    uses: dbt-labs/dbt-release/.github/workflows/_github-release.yml@main
+
+    with:
+      sha: ${{ inputs.sha }}
+      version_number: ${{ inputs.version_number }}
+      changelog_path: ${{ inputs.changelog_path }}
+      test_run: ${{ inputs.test_run }}
+
+  pypi-release:
+    if: ${{ !inputs.test_run }}
+
+    name: Pypi Release
+
+    runs-on: ubuntu-latest
+
+    needs: github-release
+
+    environment: PypiProd
+
+    steps:
+      - name: "Download Build Artifact - ${{ inputs.version_number }}"
+        uses: actions/download-artifact@v3
+        with:
+          name: ${{ inputs.version_number }}
+          path: "dist"
+
+      - name: "Publish Distribution To Pypi"
+        uses: pypa/gh-action-pypi-publish@v1.4.2
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,7 +59,7 @@ jobs:
 
     needs: build-test-package
 
-    uses: dbt-labs/dbt-release/.github/workflows/_github-release.yml@main
+    uses: dbt-labs/dbt-release/.github/workflows/github-release.yml@main
 
     with:
       sha: ${{ inputs.sha }}


### PR DESCRIPTION
**Description**: 
We need to introduce the release workflow in order to test the work of the GitHub Release reusable workflow against dbt adapters.

_Chnagelog_:
- Add `release.yml` - Release to GitHub and PyPi
- Add `build-test-package.yml` - Build, Test, and Package