### PR TITLE
[CI/CD] Replace build steps with build workflow

### DIFF
--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -35,35 +35,35 @@ jobs:
           echo Python target version:              ${{ env.PYTHON_TARGET_VERSION }}
           echo Artifact retention days:            ${{ env.ARTIFACT_RETENTION_DAYS }}
 
-  unit:
-    name: Unit Test
+  # unit:
+  #   name: Unit Test
 
-    runs-on: ubuntu-latest
+  #   runs-on: ubuntu-latest
 
-    env:
-      TOXENV: "unit"
+  #   env:
+  #     TOXENV: "unit"
 
-    steps:
-      - name: "Checkout Commit - ${{ inputs.sha }}"
-        uses: actions/checkout@v3
-        with:
-          persist-credentials: false
-          ref: ${{ github.event.inputs.sha }}
+  #   steps:
+  #     - name: "Checkout Commit - ${{ inputs.sha }}"
+  #       uses: actions/checkout@v3
+  #       with:
+  #         persist-credentials: false
+  #         ref: ${{ github.event.inputs.sha }}
 
-      - name: "Set up Python - ${{ env.PYTHON_TARGET_VERSION }}"
-        uses: actions/setup-python@v4
-        with:
-          python-version: ${{ env.PYTHON_TARGET_VERSION }}
+  #     - name: "Set up Python - ${{ env.PYTHON_TARGET_VERSION }}"
+  #       uses: actions/setup-python@v4
+  #       with:
+  #         python-version: ${{ env.PYTHON_TARGET_VERSION }}
 
-      - name: "Install Python Dependencies"
-        run: |
-          python -m pip install --user --upgrade pip
-          python -m pip install tox
-          python -m pip --version
-          python -m tox --version
+  #     - name: "Install Python Dependencies"
+  #       run: |
+  #         python -m pip install --user --upgrade pip
+  #         python -m pip install tox
+  #         python -m pip --version
+  #         python -m tox --version
 
-      - name: "Run Tox"
-        run: tox
+  #     - name: "Run Tox"
+  #       run: tox
 
   build:
     name: Build Packages
@@ -129,7 +129,7 @@ jobs:
 
     if: needs.build.outputs.is_alpha == 0
 
-    needs: [unit, build]
+    needs: [build]
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -70,6 +70,9 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    outputs:
+      is_alpha: ${{ steps.check-is-alpha.outputs.is_alpha }}
+
     steps:
       - name: "Checkout Commit - ${{ inputs.sha }}"
         uses: actions/checkout@v3
@@ -102,6 +105,16 @@ jobs:
         run: |
           check-wheel-contents dist/*.whl --ignore W007,W008
 
+      - name: "Check If This Is An Alpha Version"
+        id: check-is-alpha
+        run: |
+          export is_alpha=0
+          if [[ "$(ls -lh dist/)" == *"a1"* ]]; 
+          then 
+          export is_alpha=1; 
+          fi
+          echo "is_alpha=$is_alpha" >> $GITHUB_OUTPUT
+      
       - name: "Upload Build Artifact - ${{ inputs.version_number }}"
         uses: actions/upload-artifact@v3
         with:
@@ -113,6 +126,8 @@ jobs:
 
   test-build:
     name: Verify Packages
+
+    if: needs.build.outputs.is_alpha == 0
 
     needs: [unit, build]
 

--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -35,35 +35,35 @@ jobs:
           echo Python target version:              ${{ env.PYTHON_TARGET_VERSION }}
           echo Artifact retention days:            ${{ env.ARTIFACT_RETENTION_DAYS }}
 
-  # unit:
-  #   name: Unit Test
+  unit:
+    name: Unit Test
 
-  #   runs-on: ubuntu-latest
+    runs-on: ubuntu-latest
 
-  #   env:
-  #     TOXENV: "unit"
+    env:
+      TOXENV: "unit"
 
-  #   steps:
-  #     - name: "Checkout Commit - ${{ inputs.sha }}"
-  #       uses: actions/checkout@v3
-  #       with:
-  #         persist-credentials: false
-  #         ref: ${{ github.event.inputs.sha }}
+    steps:
+      - name: "Checkout Commit - ${{ inputs.sha }}"
+        uses: actions/checkout@v3
+        with:
+          persist-credentials: false
+          ref: ${{ github.event.inputs.sha }}
 
-  #     - name: "Set up Python - ${{ env.PYTHON_TARGET_VERSION }}"
-  #       uses: actions/setup-python@v4
-  #       with:
-  #         python-version: ${{ env.PYTHON_TARGET_VERSION }}
+      - name: "Set up Python - ${{ env.PYTHON_TARGET_VERSION }}"
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ env.PYTHON_TARGET_VERSION }}
 
-  #     - name: "Install Python Dependencies"
-  #       run: |
-  #         python -m pip install --user --upgrade pip
-  #         python -m pip install tox
-  #         python -m pip --version
-  #         python -m tox --version
+      - name: "Install Python Dependencies"
+        run: |
+          python -m pip install --user --upgrade pip
+          python -m pip install tox
+          python -m pip --version
+          python -m tox --version
 
-  #     - name: "Run Tox"
-  #       run: tox
+      - name: "Run Tox"
+        run: tox
 
   build:
     name: Build Packages
@@ -129,7 +129,7 @@ jobs:
 
     if: needs.build.outputs.is_alpha == 0
 
-    needs: [build]
+    needs: [unit, build]
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -109,12 +109,12 @@ jobs:
         id: check-is-alpha
         run: |
           export is_alpha=0
-          if [[ "$(ls -lh dist/)" == *"a1"* ]]; 
-          then 
-          export is_alpha=1; 
+          if [[ "$(ls -lh dist/)" == *"a1"* ]];
+          then
+          export is_alpha=1;
           fi
           echo "is_alpha=$is_alpha" >> $GITHUB_OUTPUT
-      
+
       - name: "Upload Build Artifact - ${{ inputs.version_number }}"
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,25 +67,25 @@ jobs:
       changelog_path: ${{ inputs.changelog_path }}
       test_run: ${{ inputs.test_run }}
 
-  pypi-release:
-    if: ${{ !inputs.test_run }}
+  # pypi-release:
+  #   if: ${{ !inputs.test_run }}
 
-    name: Pypi Release
+  #   name: Pypi Release
 
-    runs-on: ubuntu-latest
+  #   runs-on: ubuntu-latest
 
-    needs: github-release
+  #   needs: github-release
 
-    environment: PypiProd
+  #   environment: PypiProd
 
-    steps:
-      - name: "Download Build Artifact - ${{ inputs.version_number }}"
-        uses: actions/download-artifact@v3
-        with:
-          name: ${{ inputs.version_number }}
-          path: "dist"
+  #   steps:
+  #     - name: "Download Build Artifact - ${{ inputs.version_number }}"
+  #       uses: actions/download-artifact@v3
+  #       with:
+  #         name: ${{ inputs.version_number }}
+  #         path: "dist"
 
-      - name: "Publish Distribution To Pypi"
-        uses: pypa/gh-action-pypi-publish@v1.4.2
-        with:
-          password: ${{ secrets.PYPI_API_TOKEN }}
+  #     - name: "Publish Distribution To Pypi"
+  #       uses: pypa/gh-action-pypi-publish@v1.4.2
+  #       with:
+  #         password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,36 @@ on:
         type: string
         default: "./CHANGELOG.md"
         required: false
+      build_script_path:
+        description: "Build script path"
+        type: string
+        default: "scripts/build-dist.sh"
+        required: true
+      s3_bucket_name:
+        description: "AWS S3 bucket name"
+        type: string
+        default: "core-team-artifacts"
+        required: true
+      package_test_command:
+        description: "Package test command"
+        type: string
+        default: "dbt --version"
+        required: true
+      audit_version_changelog:
+        description: "Check version changelog"
+        type: boolean
+        default: false
+        required: false
+      check_build_exists:
+        description: "Check build exists"
+        type: boolean
+        default: false
+        required: false
+      upload_artifacts_aws:
+        description: "Upload build to AWS"
+        required: false
+        default: false
+        type: boolean
       test_run:
         description: "Test run (Publish release as draft)"
         type: boolean
@@ -32,6 +62,10 @@ on:
 
 permissions:
   contents: write # this is the permission that allows creating a new release
+
+defaults:
+  run:
+    shell: bash
 
 jobs:
   log-inputs:
@@ -43,19 +77,37 @@ jobs:
           echo The last commit sha in the release: ${{ inputs.sha }}
           echo The release version number:         ${{ inputs.version_number }}
           echo Expected Changlog path:             ${{ inputs.changelog_path }}
+          echo Build script path:                  ${{ inputs.build_script_path }}
+          echo AWS S3 bucket name:                 ${{ inputs.s3_bucket_name }}
+          echo Package test command:               ${{ inputs.package_test_command }}
+          echo Check version changelog:            ${{ inputs.audit_version_changelog }}
+          echo Check build exists:                 ${{ inputs.check_build_exists }}
+          echo Upload build to AWS:                ${{ inputs.upload_artifacts_aws  }}
           echo Test run:                           ${{ inputs.test_run }}
 
   build-test-package:
-    name: Build, Test, and Package
+    name: Build, Test, Package
 
-    uses: dbt-labs/dbt-snowflake-release-test/.github/workflows/build-test-package.yml@main
+    uses: dbt-labs/dbt-release/.github/workflows/build.yml@users/alexander-smolyakov/update-build-workflow
 
     with:
       sha: ${{ inputs.sha }}
       version_number: ${{ inputs.version_number }}
+      changelog_path: ${{ inputs.changelog_path }}
+      build_script_path: ${{ inputs.build_script_path }}
+      s3_bucket_name: ${{ inputs.s3_bucket_name }}
+      package_test_command: ${{ inputs.package_test_command }}
+      audit_version_changelog: ${{ inputs.audit_version_changelog }}
+      check_build_exists: ${{ inputs.check_build_exists }}
+      upload_artifacts_aws: ${{ inputs.upload_artifacts_aws }}
+
+    secrets:
+      AWS_ACCESS_KEY_ID: ${{ secrets.PRODUCTION_AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.PRODUCTION_AWS_SECRET_ACCESS_KEY }}
 
   github-release:
     name: GitHub Release
+    if: ${{ !failure() && !cancelled() }}
 
     needs: build-test-package
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,7 +88,7 @@ jobs:
   build-test-package:
     name: Build, Test, Package
 
-    uses: dbt-labs/dbt-release/.github/workflows/build.yml@users/alexander-smolyakov/update-build-workflow
+    uses: dbt-labs/dbt-release/.github/workflows/build.yml@main
 
     with:
       sha: ${{ inputs.sha }}
@@ -100,6 +100,7 @@ jobs:
       audit_version_changelog: ${{ inputs.audit_version_changelog }}
       check_build_exists: ${{ inputs.check_build_exists }}
       upload_artifacts_aws: ${{ inputs.upload_artifacts_aws }}
+      test_run: ${{ inputs.test_run }}
 
     secrets:
       AWS_ACCESS_KEY_ID: ${{ secrets.PRODUCTION_AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,7 @@ jobs:
   build-test-package:
     name: Build, Test, and Package
 
-    uses: dbt-labs/dbt-snowflake-release-test/.github/workflows/build-test-package.yml@users/alexander-smolyakov/fix-build-test-package-workflows
+    uses: dbt-labs/dbt-snowflake-release-test/.github/workflows/build-test-package.yml@main
 
     with:
       sha: ${{ inputs.sha }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,25 +67,25 @@ jobs:
       changelog_path: ${{ inputs.changelog_path }}
       test_run: ${{ inputs.test_run }}
 
-  # pypi-release:
-  #   if: ${{ !inputs.test_run }}
+  pypi-release:
+    if: ${{ !inputs.test_run }}
 
-  #   name: Pypi Release
+    name: Pypi Release
 
-  #   runs-on: ubuntu-latest
+    runs-on: ubuntu-latest
 
-  #   needs: github-release
+    needs: github-release
 
-  #   environment: PypiProd
+    environment: PypiProd
 
-  #   steps:
-  #     - name: "Download Build Artifact - ${{ inputs.version_number }}"
-  #       uses: actions/download-artifact@v3
-  #       with:
-  #         name: ${{ inputs.version_number }}
-  #         path: "dist"
+    steps:
+      - name: "Download Build Artifact - ${{ inputs.version_number }}"
+        uses: actions/download-artifact@v3
+        with:
+          name: ${{ inputs.version_number }}
+          path: "dist"
 
-  #     - name: "Publish Distribution To Pypi"
-  #       uses: pypa/gh-action-pypi-publish@v1.4.2
-  #       with:
-  #         password: ${{ secrets.PYPI_API_TOKEN }}
+      - name: "Publish Distribution To Pypi"
+        uses: pypa/gh-action-pypi-publish@v1.4.2
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,7 @@ jobs:
   build-test-package:
     name: Build, Test, and Package
 
-    uses: dbt-labs/dbt-snowflake-release-test/.github/workflows/build-test-package.yml@main
+    uses: dbt-labs/dbt-snowflake-release-test/.github/workflows/build-test-package.yml@users/alexander-smolyakov/fix-build-test-package-workflows
 
     with:
       sha: ${{ inputs.sha }}


### PR DESCRIPTION
**Description**:
We need to update the current release workflow to test the Build reusable workflow.

_Changelog_:
- Fixed `build-test-package` workflow.
- Replace unit, build, and test-build stages with Build workflows;
- Add inputs required for Build workflows;

**Note**:
Merge only after:
- dbt-labs/dbt-release/pull/37
