### PR TITLE
[CI/CD] Update release workflow to add Release Preparation reusable workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,7 +83,7 @@ jobs:
   bump-version-generate-changelog:
     name: Bump package version, Generate changelog
 
-    uses: dbt-labs/dbt-release/.github/workflows/release-prep.yml@users/alexander-smolyakov/update-release-prep-workflow
+    uses: dbt-labs/dbt-release/.github/workflows/release-prep.yml@main
 
     with:
       sha: ${{ inputs.sha }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,7 +94,7 @@ jobs:
     with:
       sha: ${{ inputs.sha }}
       version_number: ${{ inputs.version_number }}
-      target_branch: ${{ input.target_branch }}
+      target_branch: ${{ inputs.target_branch }}
 
   log-outputs-bump-version-generate-changelog:
     name: "[Log output] Bump package version, Generate changelog"
@@ -112,7 +112,7 @@ jobs:
 
   build-test-package:
     name: Build, Test, Package
-    if: ${{ input.test_build_package == true && (!failure() && !cancelled()) }}
+    if: ${{ inputs.test_build_package == true && (!failure() && !cancelled()) }}
     needs: [bump-version-generate-changelog]
 
     uses: dbt-labs/dbt-release/.github/workflows/build.yml@main
@@ -132,7 +132,7 @@ jobs:
 
   github-release:
     name: GitHub Release
-    if: ${{ input.test_publish_release == true && (!failure() && !cancelled()) }}
+    if: ${{ inputs.test_publish_release == true && (!failure() && !cancelled()) }}
 
     needs: [bump-version-generate-changelog, build-test-package]
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,11 +25,6 @@ on:
         description: "The release version number (i.e. 1.0.0b1)"
         type: string
         required: true
-      changelog_path:
-        description: "Path to changes log"
-        type: string
-        default: "./CHANGELOG.md"
-        required: false
       build_script_path:
         description: "Build script path"
         type: string
@@ -78,7 +73,6 @@ jobs:
           echo The last commit sha in the release: ${{ inputs.sha }}
           echo The branch to release from:         ${{ inputs.target_branch }}
           echo The release version number:         ${{ inputs.version_number }}
-          echo Expected Changlog path:             ${{ inputs.changelog_path }}
           echo Build script path:                  ${{ inputs.build_script_path }}
           echo AWS S3 bucket name:                 ${{ inputs.s3_bucket_name }}
           echo Package test command:               ${{ inputs.package_test_command }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,9 +15,15 @@ on:
     inputs:
       sha:
         description: "The last commit sha in the release"
+        type: string
+        required: true
+      target_branch:
+        description: "The branch to release from"
+        type: string
         required: true
       version_number:
         description: "The release version number (i.e. 1.0.0b1)"
+        type: string
         required: true
       changelog_path:
         description: "Path to changes log"
@@ -44,6 +50,16 @@ on:
         type: boolean
         default: false
         required: false
+      test_build_package:
+        description: "[Test] Build package"
+        type: boolean
+        default: false
+        required: false
+      test_publish_release:
+        description: "[Test] Publish package"
+        type: boolean
+        default: false
+        required: false
 
 permissions:
   contents: write # this is the permission that allows creating a new release
@@ -60,22 +76,51 @@ jobs:
       - name: "[DEBUG] Print Variables"
         run: |
           echo The last commit sha in the release: ${{ inputs.sha }}
+          echo The branch to release from:         ${{ inputs.target_branch }}
           echo The release version number:         ${{ inputs.version_number }}
           echo Expected Changlog path:             ${{ inputs.changelog_path }}
           echo Build script path:                  ${{ inputs.build_script_path }}
           echo AWS S3 bucket name:                 ${{ inputs.s3_bucket_name }}
           echo Package test command:               ${{ inputs.package_test_command }}
           echo Test run:                           ${{ inputs.test_run }}
+          echo [Test] Build package:               ${{ inputs.test_build_package }}
+          echo [Test] Publish package:             ${{ inputs.test_publish_release }}
 
-  build-test-package:
-    name: Build, Test, Package
+  bump-version-generate-changelog:
+    name: Bump package version, Generate changelog
 
-    uses: dbt-labs/dbt-release/.github/workflows/build.yml@main
+    uses: dbt-labs/dbt-release/.github/workflows/release-prep.yml@users/alexander-smolyakov/update-release-prep-workflow
 
     with:
       sha: ${{ inputs.sha }}
       version_number: ${{ inputs.version_number }}
-      changelog_path: ${{ inputs.changelog_path }}
+      target_branch: ${{ input.target_branch }}
+
+  log-outputs-bump-version-generate-changelog:
+    name: "[Log output] Bump package version, Generate changelog"
+    if: ${{ !failure() && !cancelled() }}
+
+    needs: [bump-version-generate-changelog]
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Print variables
+        run: |
+          echo Final SHA     : ${{ needs.bump-version-generate-changelog.outputs.final_sha }}
+          echo Changelog path: ${{ needs.bump-version-generate-changelog.outputs.changelog_path }}
+
+  build-test-package:
+    name: Build, Test, Package
+    if: ${{ input.test_build_package == true && (!failure() && !cancelled()) }}
+    needs: [bump-version-generate-changelog]
+
+    uses: dbt-labs/dbt-release/.github/workflows/build.yml@main
+
+    with:
+      sha: ${{ needs.bump-version-generate-changelog.outputs.final_sha }}
+      version_number: ${{ inputs.version_number }}
+      changelog_path: ${{ needs.bump-version-generate-changelog.outputs.changelog_path }}
       build_script_path: ${{ inputs.build_script_path }}
       s3_bucket_name: ${{ inputs.s3_bucket_name }}
       package_test_command: ${{ inputs.package_test_command }}
@@ -87,16 +132,16 @@ jobs:
 
   github-release:
     name: GitHub Release
-    if: ${{ !failure() && !cancelled() }}
+    if: ${{ input.test_publish_release == true && (!failure() && !cancelled()) }}
 
-    needs: build-test-package
+    needs: [bump-version-generate-changelog, build-test-package]
 
     uses: dbt-labs/dbt-release/.github/workflows/github-release.yml@main
 
     with:
-      sha: ${{ inputs.sha }}
+      sha: ${{ needs.bump-version-generate-changelog.outputs.final_sha }}
       version_number: ${{ inputs.version_number }}
-      changelog_path: ${{ inputs.changelog_path }}
+      changelog_path: ${{ needs.bump-version-generate-changelog.outputs.changelog_path }}
       test_run: ${{ inputs.test_run }}
 
   pypi-release:


### PR DESCRIPTION
**Description**:
To test the Release Preparation reusable workflow we need to update release workflow.

_Changelog_:
- Add `bump-version-generate-changelog` stage to use Release Preparation workflow;
- Add `log-outputs-bump-version-generate-changelog` stage to print Release Preparation workflow outputs;
- Update `build-test-package` and `github-release` stages to respect Release Preparation workflow outputs;
- Add `test_build_package` and `test_publish_release` to tweak workflow behavior.