### PR TITLE
[CI/CD] Add dummy nightly release workflow definition

### DIFF
--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -1,0 +1,21 @@
+name: Nightly Release to GitHub and PyPi
+
+on:
+  workflow_dispatch:
+    inputs:
+      version_number:
+        description: "The release version number (i.e. 1.0.0b1)"
+        type: string
+        required: true
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  dummy-job:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Display Version
+        run: |
+          echo ${{ inputs.version_number }}


### PR DESCRIPTION
**Description**:
We plan to make nightly releases. This pr adds a dummy workflow definition to activate it in the `Action` section.
