### PR TITLE
[CI/CD] Add `slack-notification` stage to release workflow 

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -148,3 +148,20 @@ jobs:
     secrets:
       PYPI_API_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
       TEST_PYPI_API_TOKEN: ${{ secrets.TEST_PYPI_API_TOKEN }}
+
+  slack-notification:
+    name: Slack Notification
+    if: ${{ always() }}
+
+    needs:
+      [
+        bump-version-generate-changelog,
+        build-test-package,
+        github-release,
+        pypi-release,
+      ]
+
+    uses: dbt-labs/dbt-release/.github/workflows/slack-post-notification.yml@dev
+
+    secrets:
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_TEST_CHANNEL }}


### PR DESCRIPTION
**Description**:
To test slack notifications, we need to update the release workflow.

_Changelog_:
- Added `slack-notification` stage definition;