### PR TITLE
[CI/CD] Change `slack-post-notification` stage configuration

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -151,7 +151,7 @@ jobs:
 
   slack-notification:
     name: Slack Notification
-    if: ${{ always() }}
+    if: ${{ failure() }}
 
     needs:
       [
@@ -162,6 +162,8 @@ jobs:
       ]
 
     uses: dbt-labs/dbt-release/.github/workflows/slack-post-notification.yml@dev
+    with:
+      status: "failure"
 
     secrets:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_TEST_CHANNEL }}


### PR DESCRIPTION
**Description**:
Update the `slack-post-notification` stage configuration to send notifications only on failure.